### PR TITLE
Test against correct Kafka version

### DIFF
--- a/brute-force-serde/build.gradle.kts
+++ b/brute-force-serde/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.testcontainers.localstack)
 
+    testImplementation(platform(libs.kafka.bom))
     testImplementation(libs.fluentKafkaStreamsTests)
     testImplementation(libs.protobuf)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,6 @@ allprojects {
         maxParallelForks = 4
         useJUnitPlatform()
     }
-
-    repositories {
-        mavenCentral()
-        maven(url = "https://packages.confluent.io/maven/")
-        maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots")
-    }
 }
 
 subprojects {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,15 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+    repositories {
+        mavenCentral()
+        maven(url = "https://packages.confluent.io/maven/")
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots")
+    }
+}
+
 rootProject.name = "brute-force"
 
 include(":brute-force-core", ":brute-force-serde", ":brute-force-connect")


### PR DESCRIPTION
Before that, transitive version provided by fluent-kafka-streams-tests was used